### PR TITLE
Attempt to force url for artifact to contain tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,3 +61,6 @@ jobs:
         allowUpdates: true
         updateOnlyUnreleased: true
         omitBodyDuringUpdate: true
+
+        # Make sure the release created is acutally associated with the tag properly
+        tag: ${GITHUB_REF#refs/*/}


### PR DESCRIPTION
When releases are created by GitHub action, the source Zip can be recovered by a URL that contains the tag. However, the build artifact is uploaded to a URL that is untagged.